### PR TITLE
Make script usable on both NVMe and SATA SSD disks

### DIFF
--- a/configuration-template.nix
+++ b/configuration-template.nix
@@ -14,7 +14,7 @@
   boot.initrd.luks.devices = [
     {
       name = "root";
-      device = "##device##n2"; 
+      device = "##device##2"; 
       preLVM = true;
     }
   ];

--- a/install.sh
+++ b/install.sh
@@ -63,8 +63,11 @@ run_cryptsetup(){
   echo -n "[-] Encrypting the disk... "
   INST_PASSWD=$(diceware -s 1 -n 2);
   INST_PASSWD_SHA512=$(mkpasswd  -m sha-512 -s <<< ${INST_PASSWD})
-  echo -n $INST_PASSWD | cryptsetup -q luksFormat ${INST_DEVICE}p2 -
-  echo -n $INST_PASSWD | cryptsetup luksOpen ${INST_DEVICE}p2 enc-pv -d -
+  if [ -b /dev/nvme0n1 ]; then
+    export INST_DEVICE=$INST_DEVICE"p"
+  fi
+  echo -n $INST_PASSWD | cryptsetup -q luksFormat ${INST_DEVICE}2 -
+  echo -n $INST_PASSWD | cryptsetup luksOpen ${INST_DEVICE}2 enc-pv -d -
   echo "done."
 }
 
@@ -76,7 +79,7 @@ run_fssetup(){
   lvcreate -n root vg -l 100%FREE >/dev/null
   echo "done."
   echo -n "[-] Formating filesystems... "
-  mkfs.fat -F 32 -n boot ${INST_DEVICE}p1 >/dev/null 2>&1
+  mkfs.fat -F 32 -n boot ${INST_DEVICE}1 >/dev/null 2>&1
   mkfs.ext4 -L root /dev/vg/root >/dev/null >/dev/null 2>&1
   mkswap -L swap /dev/vg/swap >/dev/null 2>&1
   echo "done."


### PR DESCRIPTION
Please have a look at this solution or propose something better. Currently it doesn't work on regular SATA disks and fails during Encrypting step (as there's no /dev/sdap2 device)