### PR TITLE
Explicitly disable libinput (in order to use synaptics)

### DIFF
--- a/configuration-template.nix
+++ b/configuration-template.nix
@@ -152,7 +152,8 @@
   services.xserver.xkbOptions = "eurosign:e";
 
   # Enable touchpad support.
-  # services.xserver.libinput.enable = true;
+  # It is needed to explicitly disable libinput if we want to use synaptics
+  services.xserver.libinput.enable = false;
   
   # Enable Lenovo/IBM touchpad support
   services.xserver.synaptics.enable = true;


### PR DESCRIPTION
It is needed to explicitly disable libinput if we want to use synaptics module. Otherwise the build fails.