### PR TITLE
Enable gnupg agent as pinentry won't work in Engimail

### DIFF
--- a/configuration-template.nix
+++ b/configuration-template.nix
@@ -120,6 +120,9 @@
   # programs.mtr.enable = true;
   # programs.gnupg.agent = { enable = true; enableSSHSupport = true; };
 
+  # As GnuPG is now built without support for a graphical passphrase entry by default 
+  programs.gnupg.agent.enable = true;
+
   # List services that you want to enable:
 
   # Enable the OpenSSH daemon.


### PR DESCRIPTION
As per https://github.com/NixOS/nixpkgs/blob/a692029726e85656dec6e350b9c4a90cfa0c43b8/nixos/doc/manual/release-notes/rl-2003.xml#L95-L100